### PR TITLE
Add Campaign Kit Admin API Docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,44 @@
+# Campaign Kit Admin API
+
+This document describes the API designed to integrate Campaign Kit with other systems. It is specifically intended to manage creation and deletion of kits, campaigns, places, and content.
+
+Data synchronization, communicating with the SDKs, configuring hardware is not part of the Admin API. Radius Networks has [other resources](http://developer.radiusnetworks.com/) for many of those needs.
+
+## Overview
+
+The API uses IDs for linkage, which makes it possible to cache documents from compound responses and then limit subsequent requests to only the documents that aren't already present locally.
+
+Resource relationships are created through the use of URI templates and resource identifiers. To prevent future breakage we recommend creating the URIs from the templates over hardcoding to the individual resources.
+
+## Headers
+
+### Authorization
+
+The API Key is passed via the Authorization header:
+
+    Authorization: Token token="secret"
+
+The API Key is associated with your account and has access to all the resources associated with your account. Account-specific API keys have different permissions than the web login users that can interact with the dashboard, and the access may be different.
+
+Example:
+
+    curl -H 'Authorization: Token token="sandbox"' "https://campaignkit.radiusnetworks.com/api/v1.json"
+
+API Tokens can be managed in your [Radius Networks Account Profile](https://account.radiusnetworks.com/personal_tokens).
+
+Note: Per [RFC 2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2.2) the Authorization Header's token needs to be surrounded by double quotes (`"`).
+
+### Content Type
+
+The content type is `vnd+json`, and should be set in the Content-Type header:
+
+    Content-Type: application/vnd.api+json
+
+# Resources
+
+- [Root Endpoint](api/v1/root_endpoint.md)
+- [Kits](api/v1/kits.md)
+- [Campaigns](api/v1/campaigns.md)
+- [Assets](api/v1/assets.md)
+- [Contents](api/v1/contents.md)
+- [Places](api/v1/places.md)

--- a/docs/api/v1/assets.md
+++ b/docs/api/v1/assets.md
@@ -1,0 +1,167 @@
+# Assets API
+
+- [Listing A Kit's Assets](#listing-a-kit's-assets)
+- [Getting A Asset](#getting-a-asset)
+
+All actions against assets require at a minimum an authenticated user who
+is the owner, or a member of the kit to which the kit belongs.
+
+## Headers <a href="#headers" id="headers" class="headerlink"></a>
+
+### Authorization <a href="#authorization" id="authorization" class="headerlink"></a>
+
+The API Key is passed via the Authorization header:
+
+```
+Authorization: Token token="secret"
+```
+
+The API Key is associated with your account and has access to all the resources
+associated with your account. Account specific API keys have different
+permissions than the web login users that can interact with the dashboard, and
+the access may be different.
+
+If you do not have an API key, [you can create one here](https://account.radiusnetworks.com/personal_token).
+
+**Note:** Per [RFC 2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2.2) the Authorization Header's token needs to be
+surrounded by double quotes (`"`).
+
+### Content Type <a href="#content-type" id="content-type" class="headerlink"></a>
+
+The content type is `vnd.rn+json` and should be set in the `Content-Type`
+header:
+
+```
+Content-Type: application/vnd.rn+json
+```
+
+## Listing A Kit's Assets <a href="#listing-a-kit's-assets" class="header-link"></a>
+
+```
+GET /api/v1/kits/2/assets
+```
+
+List assets for the specified kit.
+
+Assets are associated to a specific `Kit`. The desired kit's `id`
+must be provided in the URL.
+
+### Response <a href="#listing-a-kit's-assets-response" class="header-link"></a>
+
+```
+Status: 200 OK
+Content-Type: application/json; charset=utf-8
+CampaignKit-Media-Type: campaignkit.v1
+CampaignKit-API-Version: 1.0
+```
+```json
+{
+  "links": {
+    "assets.kit": "https://campaignkit.radiusnetworks.com/api/v1/kits/{assets.kit}"
+  },
+  "assets": [
+    {
+      "id": "5",
+      "name": "yvnmwpwjfxsyvmjgovqn",
+      "type": "Asset",
+      "media": {
+        "media": {
+          "url": null,
+          "thumb": {
+            "url": null
+          }
+        }
+      },
+      "created_at": "2015-07-06T18:03:30.953Z",
+      "updated_at": "2015-07-06T18:03:30.953Z",
+      "links": {
+        "kit": "2"
+      }
+    },
+    {
+      "id": "6",
+      "name": "igdujxzdqcdeeeubjwwm",
+      "type": "Asset",
+      "media": {
+        "media": {
+          "url": null,
+          "thumb": {
+            "url": null
+          }
+        }
+      },
+      "created_at": "2015-07-06T18:03:30.958Z",
+      "updated_at": "2015-07-06T18:03:30.958Z",
+      "links": {
+        "kit": "2"
+      }
+    }
+  ]
+}
+```
+
+### Curl Example <a href="#listing-a-kit's-assets-curl-example" class="header-link"></a>
+
+```
+curl https://campaignkit.radiusnetworks.com/api/v1/kits/2/assets \
+  -is \
+  -X GET \
+  -H 'Accept: application/vnd.rn+json' \
+  -H 'Content-Type: application/vnd.rn+json' \
+  -H 'Authorization: Token token="c0decafe1111180a29c8696adbd5307ccdcdaa6468c0ffee"'
+```
+
+## Getting A Asset <a href="#getting-a-asset" class="header-link"></a>
+
+```
+GET /api/v1/assets/21
+```
+
+List a specific asset for the authenticated user. The desired assets's `id` needs to be provided in the URL.
+
+### Response <a href="#getting-a-asset-response" class="header-link"></a>
+
+```
+Status: 200 OK
+Content-Type: application/json; charset=utf-8
+CampaignKit-Media-Type: campaignkit.v1
+CampaignKit-API-Version: 1.0
+```
+```json
+{
+  "links": {
+    "assets.kit": "https://campaignkit.radiusnetworks.com/api/v1/kits/{assets.kit}"
+  },
+  "assets": [
+    {
+      "id": "21",
+      "name": "aunpgqhfdfbszytzwzie",
+      "type": "Asset",
+      "media": {
+        "media": {
+          "url": null,
+          "thumb": {
+            "url": null
+          }
+        }
+      },
+      "created_at": "2015-07-06T18:03:31.277Z",
+      "updated_at": "2015-07-06T18:03:31.277Z",
+      "links": {
+        "kit": "2"
+      }
+    }
+  ]
+}
+```
+
+### Curl Example <a href="#getting-a-asset-curl-example" class="header-link"></a>
+
+```
+curl https://campaignkit.radiusnetworks.com/api/v1/assets/21 \
+  -is \
+  -X GET \
+  -H 'Accept: application/vnd.rn+json' \
+  -H 'Content-Type: application/vnd.rn+json' \
+  -H 'Authorization: Token token="c0decafe1111180a29c8696adbd5307ccdcdaa6468c0ffee"'
+```

--- a/docs/api/v1/campaigns.md
+++ b/docs/api/v1/campaigns.md
@@ -1,0 +1,531 @@
+# Campaigns API
+
+- [Listing A Kit's Campaigns](#listing-a-kit's-campaigns)
+- [Getting A Campaign](#getting-a-campaign)
+- [Creating A Campaign](#creating-a-campaign)
+- [Updating A Campaign Changing An Attribute](#updating-a-campaign-changing-an-attribute)
+- [Updating A Campaign Not Changing An Attribute](#updating-a-campaign-not-changing-an-attribute)
+- [Deleting A Campaign](#deleting-a-campaign)
+
+All actions against campaigns require at a minimum an authenticated user who
+is the owner, or a member of the kit to which the kit belongs.
+
+## Headers <a href="#headers" id="headers" class="headerlink"></a>
+
+### Authorization <a href="#authorization" id="authorization" class="headerlink"></a>
+
+The API Key is passed via the Authorization header:
+
+```
+Authorization: Token token="secret"
+```
+
+The API Key is associated with your account and has access to all the resources
+associated with your account. Account specific API keys have different
+permissions than the web login users that can interact with the dashboard, and
+the access may be different.
+
+If you do not have an API key, [you can create one here](https://account.radiusnetworks.com/personal_token).
+
+**Note:** Per [RFC 2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2.2) the Authorization Header's token needs to be
+surrounded by double quotes (`"`).
+
+### Content Type <a href="#content-type" id="content-type" class="headerlink"></a>
+
+The content type is `vnd.rn+json` and should be set in the `Content-Type`
+header:
+
+```
+Content-Type: application/vnd.rn+json
+```
+
+## Listing A Kit's Campaigns <a href="#listing-a-kit's-campaigns" class="header-link"></a>
+
+```
+GET /api/v1/kits/4/campaigns
+```
+
+List campaigns for the specified kit.
+
+Campaigns are associated to a specific `Kit`. The desired kit's `id`
+must be provided in the URL.
+
+### Response <a href="#listing-a-kit's-campaigns-response" class="header-link"></a>
+
+```
+Status: 200 OK
+Content-Type: application/json; charset=utf-8
+CampaignKit-Media-Type: campaignkit.v1
+CampaignKit-API-Version: 1.0
+```
+```json
+{
+  "links": {
+    "campaigns.kit": "https://campaignkit.radiusnetworks.com/api/v1/kits/{campaigns.kit}"
+  },
+  "campaigns": [
+    {
+      "id": "8",
+      "name": "kfemuvzwbszsmrzucary",
+      "start_at": null,
+      "end_at": null,
+      "min_recur_secs": -1,
+      "foreground_only": false,
+      "active": true,
+      "trigger_distance": null,
+      "created_at": "2015-07-06T18:03:31.734Z",
+      "updated_at": "2015-07-06T18:03:31.734Z",
+      "links": {
+        "kit": "4",
+        "content": "1",
+        "places": [
+          1
+        ],
+        "fulfillment_places": [
+
+        ]
+      }
+    },
+    {
+      "id": "9",
+      "name": "qxnbnzvrztlopzmyiyrs",
+      "start_at": null,
+      "end_at": null,
+      "min_recur_secs": -1,
+      "foreground_only": false,
+      "active": true,
+      "trigger_distance": null,
+      "created_at": "2015-07-06T18:03:31.748Z",
+      "updated_at": "2015-07-06T18:03:31.748Z",
+      "links": {
+        "kit": "4",
+        "content": "1",
+        "places": [
+          1
+        ],
+        "fulfillment_places": [
+
+        ]
+      }
+    },
+    {
+      "id": "10",
+      "name": "zysxmkkksrstmhmerugb",
+      "start_at": null,
+      "end_at": null,
+      "min_recur_secs": -1,
+      "foreground_only": false,
+      "active": true,
+      "trigger_distance": null,
+      "created_at": "2015-07-06T18:03:31.763Z",
+      "updated_at": "2015-07-06T18:03:31.763Z",
+      "links": {
+        "kit": "4",
+        "content": "1",
+        "places": [
+          1
+        ],
+        "fulfillment_places": [
+
+        ]
+      }
+    },
+    {
+      "id": "11",
+      "name": "kckcxeslbdntwqqadjfv",
+      "start_at": null,
+      "end_at": null,
+      "min_recur_secs": -1,
+      "foreground_only": false,
+      "active": true,
+      "trigger_distance": null,
+      "created_at": "2015-07-06T18:03:31.778Z",
+      "updated_at": "2015-07-06T18:03:31.778Z",
+      "links": {
+        "kit": "4",
+        "content": "1",
+        "places": [
+          1
+        ],
+        "fulfillment_places": [
+
+        ]
+      }
+    }
+  ]
+}
+```
+
+### Curl Example <a href="#listing-a-kit's-campaigns-curl-example" class="header-link"></a>
+
+```
+curl https://campaignkit.radiusnetworks.com/api/v1/kits/4/campaigns \
+  -is \
+  -X GET \
+  -H 'Accept: application/vnd.rn+json' \
+  -H 'Content-Type: application/vnd.rn+json' \
+  -H 'Authorization: Token token="c0decafe1111180a29c8696adbd5307ccdcdaa6468c0ffee"'
+```
+
+## Getting A Campaign <a href="#getting-a-campaign" class="header-link"></a>
+
+```
+GET /api/v1/campaigns/32
+```
+
+List a specific campaign for the authenticated user. The desired campaigns's `id` needs to be provided in the URL.
+
+### Response <a href="#getting-a-campaign-response" class="header-link"></a>
+
+```
+Status: 200 OK
+Content-Type: application/json; charset=utf-8
+CampaignKit-Media-Type: campaignkit.v1
+CampaignKit-API-Version: 1.0
+```
+```json
+{
+  "links": {
+    "campaigns.kit": "https://campaignkit.radiusnetworks.com/api/v1/kits/{campaigns.kit}"
+  },
+  "campaigns": [
+    {
+      "id": "32",
+      "name": "gdoomfrzxbyizrzrmfcy",
+      "start_at": null,
+      "end_at": null,
+      "min_recur_secs": -1,
+      "foreground_only": false,
+      "active": true,
+      "trigger_distance": null,
+      "created_at": "2015-07-06T18:03:32.287Z",
+      "updated_at": "2015-07-06T18:03:32.287Z",
+      "links": {
+        "kit": "4",
+        "content": "3",
+        "places": [
+          3
+        ],
+        "fulfillment_places": [
+
+        ]
+      }
+    }
+  ]
+}
+```
+
+### Curl Example <a href="#getting-a-campaign-curl-example" class="header-link"></a>
+
+```
+curl https://campaignkit.radiusnetworks.com/api/v1/campaigns/32 \
+  -is \
+  -X GET \
+  -H 'Accept: application/vnd.rn+json' \
+  -H 'Content-Type: application/vnd.rn+json' \
+  -H 'Authorization: Token token="c0decafe1111180a29c8696adbd5307ccdcdaa6468c0ffee"'
+```
+
+## Creating A Campaign <a href="#creating-a-campaign" class="header-link"></a>
+
+```
+POST /api/v1/kits/1/campaigns
+```
+
+Create a campaign for the specified kit. The desired kit's `id` must be
+provided in the URL. In order to create a campaign, the authenticated
+user must be a member of the kit.
+
+### Parameters <a href="#creating-a-campaign-parameters" class="header-link"></a>
+
+All campaigns **must** be sent in an array nested under a top level
+`campaigns` parameter.
+
+| **Name** | **Type** | **Description** |
+| -------- | -------- | --------------- |
+| `name` | `string` | Display name of the campaign (e.g. Weekly Promo, Fall Favorites, BOGO) |
+| `start_at` | `datetime` | The start date/time of the campaign |
+| `end_at` | `datetime` | The end date/time of the campaign |
+| `min_recur_secs` | `integer` | **Required.** The minimum recurrence of the campaign in seconds. By default, a campaign is
+	      one time only (value -1). |
+| `foreground_only` | `string` | Set to true to make the campaing forground only |
+| `active` | `string` | Set to true to make the campaing active, set to false to disable campaign |
+| `trigger_distance` | `integer` | Minimum distance before campaign is triggered |
+| `content_id` | `integer` | **Required.** ID of the content associated with this campaign |
+| `place_ids` | `integer` | **Required.** Array if IDs of the places where this campaign is being hosted |
+| `fulfillment_place_ids` | `integer` | Array if IDs of the places where this campaign can be fulfilled |
+
+### Example <a href="#creating-a-campaign-example" class="header-link"></a>
+
+A successful campaign creation returns the generated campaign document with
+updated timestamps.
+
+```json
+{
+  "campaigns": {
+    "name": "RSpec Campaign 1",
+    "content_id": "6",
+    "place_ids": [
+      6
+    ]
+  }
+}
+```
+
+### Response <a href="#creating-a-campaign-response" class="header-link"></a>
+
+```
+Status: 201 Created
+Content-Type: application/json; charset=utf-8
+CampaignKit-Media-Type: campaignkit.v1
+CampaignKit-API-Version: 1.0
+```
+```json
+{
+  "links": {
+    "campaigns.kit": "https://campaignkit.radiusnetworks.com/api/v1/kits/{campaigns.kit}"
+  },
+  "campaigns": [
+    {
+      "id": "58",
+      "name": "RSpec Campaign 1",
+      "start_at": null,
+      "end_at": null,
+      "min_recur_secs": -1,
+      "foreground_only": false,
+      "active": true,
+      "trigger_distance": null,
+      "created_at": "2015-07-06T18:03:32.839Z",
+      "updated_at": "2015-07-06T18:03:32.839Z",
+      "links": {
+        "kit": "1",
+        "content": "6",
+        "places": [
+          6
+        ],
+        "fulfillment_places": [
+
+        ]
+      }
+    }
+  ]
+}
+```
+
+### Curl Example <a href="#creating-a-campaign-curl-example" class="header-link"></a>
+
+```
+curl https://campaignkit.radiusnetworks.com/api/v1/kits/1/campaigns \
+  -is \
+  -X POST \
+  -H 'Accept: application/vnd.rn+json' \
+  -H 'Content-Type: application/vnd.rn+json' \
+  -H 'Authorization: Token token="c0decafe1111180a29c8696adbd5307ccdcdaa6468c0ffee"' \
+  -d '{
+    "campaigns": {
+      "name": "RSpec Campaign 1",
+      "content_id": "6",
+      "place_ids": [
+        6
+      ]
+    }
+  }'
+```
+
+## Updating A Campaign Changing An Attribute <a href="#updating-a-campaign-changing-an-attribute" class="header-link"></a>
+
+```
+PUT /api/v1/campaigns/86
+```
+
+In order to update a campaign, the authenticated user must be a member of
+the kit that the campaign is associated with.
+
+### Parameters <a href="#updating-a-campaign-changing-an-attribute-parameters" class="header-link"></a>
+
+All campaigns **must** be sent in an array nested under a top level
+`campaigns` parameter.
+
+| **Name** | **Type** | **Description** |
+| -------- | -------- | --------------- |
+| `id` | `string` | **Required.** The id of the campaign |
+| `name` | `string` | Display name of the campaign (e.g. Weekly Promo, Fall Favorites, BOGO) |
+| `start_at` | `datetime` | The start date/time of the campaign |
+| `end_at` | `datetime` | The end date/time of the campaign |
+| `min_recur_secs` | `integer` | **Required.** The minimum recurrence of the campaign in seconds. By default, a campaign is
+	      one time only (value -1). |
+| `foreground_only` | `string` | Set to true to make the campaing forground only |
+| `active` | `string` | Set to true to make the campaing active, set to false to disable campaign |
+| `trigger_distance` | `integer` | Minimum distance before campaign is triggered |
+| `content_id` | `integer` | **Required.** ID of the content associated with this campaign |
+| `place_ids` | `integer` | **Required.** Array if IDs of the places where this campaign is being hosted |
+| `fulfillment_place_ids` | `integer` | Array if IDs of the places where this campaign can be fulfilled |
+
+### Example <a href="#updating-a-campaign-changing-an-attribute-example" class="header-link"></a>
+
+A successful update modifies the campaign's `updated_at` field.
+
+```json
+{
+  "campaigns": {
+    "id": 86,
+    "start_at": "2015-07-06T14:03:33.532Z"
+  }
+}
+```
+
+### Response <a href="#updating-a-campaign-changing-an-attribute-response" class="header-link"></a>
+
+```
+Status: 200 OK
+Content-Type: application/json; charset=utf-8
+CampaignKit-Media-Type: campaignkit.v1
+CampaignKit-API-Version: 1.0
+```
+```json
+{
+  "links": {
+    "campaigns.kit": "https://campaignkit.radiusnetworks.com/api/v1/kits/{campaigns.kit}"
+  },
+  "campaigns": [
+    {
+      "id": "86",
+      "name": "oruytdmvuwukhkaowjgi",
+      "start_at": "2015-07-06T14:03:33.532Z",
+      "end_at": null,
+      "min_recur_secs": -1,
+      "foreground_only": false,
+      "active": true,
+      "trigger_distance": null,
+      "created_at": "2015-07-06T18:03:33.431Z",
+      "updated_at": "2015-07-06T18:03:33.540Z",
+      "links": {
+        "kit": "2",
+        "content": "9",
+        "places": [
+          9
+        ],
+        "fulfillment_places": [
+
+        ]
+      }
+    }
+  ]
+}
+```
+
+### Curl Example <a href="#updating-a-campaign-changing-an-attribute-curl-example" class="header-link"></a>
+
+```
+curl https://campaignkit.radiusnetworks.com/api/v1/campaigns/86 \
+  -is \
+  -X PUT \
+  -H 'Accept: application/vnd.rn+json' \
+  -H 'Content-Type: application/vnd.rn+json' \
+  -H 'Authorization: Token token="c0decafe1111180a29c8696adbd5307ccdcdaa6468c0ffee"' \
+  -d '{
+    "campaigns": {
+      "id": 86,
+      "start_at": "2015-07-06T14:03:33.532Z"
+    }
+  }'
+```
+
+## Updating A Campaign Not Changing An Attribute <a href="#updating-a-campaign-not-changing-an-attribute" class="header-link"></a>
+
+```
+PUT /api/v1/campaigns/120
+```
+
+In order to update a campaign, the authenticated user must be a member of
+the kit that the campaign is associated with.
+
+### Parameters <a href="#updating-a-campaign-not-changing-an-attribute-parameters" class="header-link"></a>
+
+All campaigns **must** be sent in an array nested under a top level
+`campaigns` parameter.
+
+| **Name** | **Type** | **Description** |
+| -------- | -------- | --------------- |
+| `id` | `string` | **Required.** The id of the campaign |
+| `name` | `string` | Display name of the campaign (e.g. Weekly Promo, Fall Favorites, BOGO) |
+| `start_at` | `datetime` | The start date/time of the campaign |
+| `end_at` | `datetime` | The end date/time of the campaign |
+| `min_recur_secs` | `integer` | **Required.** The minimum recurrence of the campaign in seconds. By default, a campaign is
+	      one time only (value -1). |
+| `foreground_only` | `string` | Set to true to make the campaing forground only |
+| `active` | `string` | Set to true to make the campaing active, set to false to disable campaign |
+| `trigger_distance` | `integer` | Minimum distance before campaign is triggered |
+| `content_id` | `integer` | **Required.** ID of the content associated with this campaign |
+| `place_ids` | `integer` | **Required.** Array if IDs of the places where this campaign is being hosted |
+| `fulfillment_place_ids` | `integer` | Array if IDs of the places where this campaign can be fulfilled |
+
+### Example <a href="#updating-a-campaign-not-changing-an-attribute-example" class="header-link"></a>
+
+If you do not provide attributes, or if all of the provided attributes
+for a are the same, the campaign is not updated. In these cases a
+`204 No Content` response is returned.
+
+This response will have an empty body per HTTP schemantics.
+
+```json
+{
+  "campaigns": {
+    "id": 120,
+    "start_at": null
+  }
+}
+```
+
+### Response <a href="#updating-a-campaign-not-changing-an-attribute-response" class="header-link"></a>
+
+```
+Status: 204 No Content
+CampaignKit-Media-Type: campaignkit.v1
+CampaignKit-API-Version: 1.0
+```
+
+### Curl Example <a href="#updating-a-campaign-not-changing-an-attribute-curl-example" class="header-link"></a>
+
+```
+curl https://campaignkit.radiusnetworks.com/api/v1/campaigns/120 \
+  -is \
+  -X PUT \
+  -H 'Accept: application/vnd.rn+json' \
+  -H 'Content-Type: application/vnd.rn+json' \
+  -H 'Authorization: Token token="c0decafe1111180a29c8696adbd5307ccdcdaa6468c0ffee"' \
+  -d '{
+    "campaigns": {
+      "id": 120,
+      "start_at": null
+    }
+  }'
+```
+
+## Deleting A Campaign <a href="#deleting-a-campaign" class="header-link"></a>
+
+```
+DELETE /api/v1/campaigns/140
+```
+
+In order to delete a campaign, the authenticated user must be a member of
+the kit that the campaign is associated with.
+
+### Response <a href="#deleting-a-campaign-response" class="header-link"></a>
+
+```
+Status: 204 No Content
+CampaignKit-Media-Type: campaignkit.v1
+CampaignKit-API-Version: 1.0
+```
+
+### Curl Example <a href="#deleting-a-campaign-curl-example" class="header-link"></a>
+
+```
+curl https://campaignkit.radiusnetworks.com/api/v1/campaigns/140 \
+  -is \
+  -X DELETE \
+  -H 'Accept: application/vnd.rn+json' \
+  -H 'Content-Type: application/vnd.rn+json' \
+  -H 'Authorization: Token token="c0decafe1111180a29c8696adbd5307ccdcdaa6468c0ffee"'
+```

--- a/docs/api/v1/contents.md
+++ b/docs/api/v1/contents.md
@@ -1,0 +1,451 @@
+# Contents API
+
+- [Listing A Kit's Contents](#listing-a-kit's-contents)
+- [Getting A Content](#getting-a-content)
+- [Creating A Content](#creating-a-content)
+- [Updating A Content Changing An Attribute](#updating-a-content-changing-an-attribute)
+- [Updating A Content Not Changing An Attribute](#updating-a-content-not-changing-an-attribute)
+- [Deleting A Content](#deleting-a-content)
+
+All actions against contents require at a minimum an authenticated user who
+is the owner, or a member of the kit to which the kit belongs.
+
+## Headers <a href="#headers" id="headers" class="headerlink"></a>
+
+### Authorization <a href="#authorization" id="authorization" class="headerlink"></a>
+
+The API Key is passed via the Authorization header:
+
+```
+Authorization: Token token="secret"
+```
+
+The API Key is associated with your account and has access to all the resources
+associated with your account. Account specific API keys have different
+permissions than the web login users that can interact with the dashboard, and
+the access may be different.
+
+If you do not have an API key, [you can create one here](https://account.radiusnetworks.com/personal_token).
+
+**Note:** Per [RFC 2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2.2) the Authorization Header's token needs to be
+surrounded by double quotes (`"`).
+
+### Content Type <a href="#content-type" id="content-type" class="headerlink"></a>
+
+The content type is `vnd.rn+json` and should be set in the `Content-Type`
+header:
+
+```
+Content-Type: application/vnd.rn+json
+```
+
+## Listing A Kit's Contents <a href="#listing-a-kit's-contents" class="header-link"></a>
+
+```
+GET /api/v1/kits/1/contents
+```
+
+List contents for the specified kit.
+
+Contents are associated to a specific `Kit`. The desired kit's `id`
+must be provided in the URL.
+
+### Response <a href="#listing-a-kit's-contents-response" class="header-link"></a>
+
+```
+Status: 200 OK
+Content-Type: application/json; charset=utf-8
+CampaignKit-Media-Type: campaignkit.v1
+CampaignKit-API-Version: 1.0
+```
+```json
+{
+  "links": {
+    "contents.kit": "https://campaignkit.radiusnetworks.com/api/v1/kits/{contents.kit}"
+  },
+  "contents": [
+    {
+      "id": "15",
+      "name": "kshphvwphyzhlxucmlmf",
+      "version": 1,
+      "type": null,
+      "body": "<html/>",
+      "alert_title": null,
+      "alert_message": null,
+      "created_at": "2015-07-06T18:03:34.636Z",
+      "updated_at": "2015-07-06T18:03:34.636Z",
+      "links": {
+        "kit": "1"
+      }
+    },
+    {
+      "id": "16",
+      "name": "blgywiujdjmszwkudceu",
+      "version": 1,
+      "type": null,
+      "body": "<html/>",
+      "alert_title": null,
+      "alert_message": null,
+      "created_at": "2015-07-06T18:03:34.641Z",
+      "updated_at": "2015-07-06T18:03:34.641Z",
+      "links": {
+        "kit": "1"
+      }
+    },
+    {
+      "id": "17",
+      "name": "hzbfphnwyuawwqfojncj",
+      "version": 1,
+      "type": null,
+      "body": "<html/>",
+      "alert_title": null,
+      "alert_message": null,
+      "created_at": "2015-07-06T18:03:34.646Z",
+      "updated_at": "2015-07-06T18:03:34.646Z",
+      "links": {
+        "kit": "1"
+      }
+    },
+    {
+      "id": "18",
+      "name": "ysiffnqkzdqucbdojrgx",
+      "version": 1,
+      "type": null,
+      "body": "<html/>",
+      "alert_title": null,
+      "alert_message": null,
+      "created_at": "2015-07-06T18:03:34.652Z",
+      "updated_at": "2015-07-06T18:03:34.652Z",
+      "links": {
+        "kit": "1"
+      }
+    }
+  ]
+}
+```
+
+### Curl Example <a href="#listing-a-kit's-contents-curl-example" class="header-link"></a>
+
+```
+curl https://campaignkit.radiusnetworks.com/api/v1/kits/1/contents \
+  -is \
+  -X GET \
+  -H 'Accept: application/vnd.rn+json' \
+  -H 'Content-Type: application/vnd.rn+json' \
+  -H 'Authorization: Token token="c0decafe1111180a29c8696adbd5307ccdcdaa6468c0ffee"'
+```
+
+## Getting A Content <a href="#getting-a-content" class="header-link"></a>
+
+```
+GET /api/v1/contents/44
+```
+
+List a specific content for the authenticated user. The desired contents's `id` needs to be provided in the URL.
+
+### Response <a href="#getting-a-content-response" class="header-link"></a>
+
+```
+Status: 200 OK
+Content-Type: application/json; charset=utf-8
+CampaignKit-Media-Type: campaignkit.v1
+CampaignKit-API-Version: 1.0
+```
+```json
+{
+  "links": {
+    "contents.kit": "https://campaignkit.radiusnetworks.com/api/v1/kits/{contents.kit}"
+  },
+  "contents": [
+    {
+      "id": "44",
+      "name": "mfbsbrrspjzskjqxfmbj",
+      "version": 1,
+      "type": null,
+      "body": "<html/>",
+      "alert_title": null,
+      "alert_message": null,
+      "created_at": "2015-07-06T18:03:34.953Z",
+      "updated_at": "2015-07-06T18:03:34.953Z",
+      "links": {
+        "kit": "4"
+      }
+    }
+  ]
+}
+```
+
+### Curl Example <a href="#getting-a-content-curl-example" class="header-link"></a>
+
+```
+curl https://campaignkit.radiusnetworks.com/api/v1/contents/44 \
+  -is \
+  -X GET \
+  -H 'Accept: application/vnd.rn+json' \
+  -H 'Content-Type: application/vnd.rn+json' \
+  -H 'Authorization: Token token="c0decafe1111180a29c8696adbd5307ccdcdaa6468c0ffee"'
+```
+
+## Creating A Content <a href="#creating-a-content" class="header-link"></a>
+
+```
+POST /api/v1/kits/2/contents
+```
+
+Create a content for the specified kit. The desired kit's `id` must be
+provided in the URL. In order to create a content, the authenticated
+user must be a member of the kit.
+
+### Parameters <a href="#creating-a-content-parameters" class="header-link"></a>
+
+All contents **must** be sent in an array nested under a top level
+`contents` parameter.
+
+| **Name** | **Type** | **Description** |
+| -------- | -------- | --------------- |
+| `name` | `string` | Display name of the content (e.g. Weekly Promo, Fall Flyer) |
+| `version` | `integer` | Optional version number to specify a revision for this content |
+| `body` | `string` | **Required.** HTML representing the content |
+| `alert_title` | `string` | The title of the alert associated with this content |
+| `alert_message` | `string` | The message of the alert associated with this content |
+
+### Example <a href="#creating-a-content-example" class="header-link"></a>
+
+A successful content creation returns the generated content document with
+updated timestamps.
+
+```json
+{
+  "contents": {
+    "name": "RSpec Content 1",
+    "body": "<html/>"
+  }
+}
+```
+
+### Response <a href="#creating-a-content-response" class="header-link"></a>
+
+```
+Status: 201 Created
+Content-Type: application/json; charset=utf-8
+CampaignKit-Media-Type: campaignkit.v1
+CampaignKit-API-Version: 1.0
+```
+```json
+{
+  "links": {
+    "contents.kit": "https://campaignkit.radiusnetworks.com/api/v1/kits/{contents.kit}"
+  },
+  "contents": [
+    {
+      "id": "76",
+      "name": "RSpec Content 1",
+      "version": 1,
+      "type": null,
+      "body": "<html/>",
+      "alert_title": null,
+      "alert_message": null,
+      "created_at": "2015-07-06T18:03:35.284Z",
+      "updated_at": "2015-07-06T18:03:35.284Z",
+      "links": {
+        "kit": "2"
+      }
+    }
+  ]
+}
+```
+
+### Curl Example <a href="#creating-a-content-curl-example" class="header-link"></a>
+
+```
+curl https://campaignkit.radiusnetworks.com/api/v1/kits/2/contents \
+  -is \
+  -X POST \
+  -H 'Accept: application/vnd.rn+json' \
+  -H 'Content-Type: application/vnd.rn+json' \
+  -H 'Authorization: Token token="c0decafe1111180a29c8696adbd5307ccdcdaa6468c0ffee"' \
+  -d '{
+    "contents": {
+      "name": "RSpec Content 1",
+      "body": "<html/>"
+    }
+  }'
+```
+
+## Updating A Content Changing An Attribute <a href="#updating-a-content-changing-an-attribute" class="header-link"></a>
+
+```
+PUT /api/v1/contents/103
+```
+
+In order to update a content, the authenticated user must be a member of
+the kit that the content is associated with.
+
+### Parameters <a href="#updating-a-content-changing-an-attribute-parameters" class="header-link"></a>
+
+All contents **must** be sent in an array nested under a top level
+`contents` parameter.
+
+| **Name** | **Type** | **Description** |
+| -------- | -------- | --------------- |
+| `id` | `string` | **Required.** The id of the content |
+| `name` | `string` | Display name of the content (e.g. Weekly Promo, Fall Flyer) |
+| `version` | `integer` | Optional version number to specify a revision for this content |
+| `body` | `string` | **Required.** HTML representing the content |
+| `alert_title` | `string` | The title of the alert associated with this content |
+| `alert_message` | `string` | The message of the alert associated with this content |
+
+### Example <a href="#updating-a-content-changing-an-attribute-example" class="header-link"></a>
+
+A successful update modifies the content's `updated_at` field.
+
+```json
+{
+  "contents": {
+    "id": 103,
+    "body": "<html><body>updated</body></html>"
+  }
+}
+```
+
+### Response <a href="#updating-a-content-changing-an-attribute-response" class="header-link"></a>
+
+```
+Status: 200 OK
+Content-Type: application/json; charset=utf-8
+CampaignKit-Media-Type: campaignkit.v1
+CampaignKit-API-Version: 1.0
+```
+```json
+{
+  "links": {
+    "contents.kit": "https://campaignkit.radiusnetworks.com/api/v1/kits/{contents.kit}"
+  },
+  "contents": [
+    {
+      "id": "103",
+      "name": "lygthumwuiawvjjsiedy",
+      "version": 1,
+      "type": null,
+      "body": "<html><body>updated</body></html>",
+      "alert_title": null,
+      "alert_message": null,
+      "created_at": "2015-07-06T18:03:35.567Z",
+      "updated_at": "2015-07-06T18:03:35.602Z",
+      "links": {
+        "kit": "2"
+      }
+    }
+  ]
+}
+```
+
+### Curl Example <a href="#updating-a-content-changing-an-attribute-curl-example" class="header-link"></a>
+
+```
+curl https://campaignkit.radiusnetworks.com/api/v1/contents/103 \
+  -is \
+  -X PUT \
+  -H 'Accept: application/vnd.rn+json' \
+  -H 'Content-Type: application/vnd.rn+json' \
+  -H 'Authorization: Token token="c0decafe1111180a29c8696adbd5307ccdcdaa6468c0ffee"' \
+  -d '{
+    "contents": {
+      "id": 103,
+      "body": "<html><body>updated</body></html>"
+    }
+  }'
+```
+
+## Updating A Content Not Changing An Attribute <a href="#updating-a-content-not-changing-an-attribute" class="header-link"></a>
+
+```
+PUT /api/v1/contents/119
+```
+
+In order to update a content, the authenticated user must be a member of
+the kit that the content is associated with.
+
+### Parameters <a href="#updating-a-content-not-changing-an-attribute-parameters" class="header-link"></a>
+
+All contents **must** be sent in an array nested under a top level
+`contents` parameter.
+
+| **Name** | **Type** | **Description** |
+| -------- | -------- | --------------- |
+| `id` | `string` | **Required.** The id of the content |
+| `name` | `string` | Display name of the content (e.g. Weekly Promo, Fall Flyer) |
+| `version` | `integer` | Optional version number to specify a revision for this content |
+| `body` | `string` | **Required.** HTML representing the content |
+| `alert_title` | `string` | The title of the alert associated with this content |
+| `alert_message` | `string` | The message of the alert associated with this content |
+
+### Example <a href="#updating-a-content-not-changing-an-attribute-example" class="header-link"></a>
+
+If you do not provide attributes, or if all of the provided attributes
+for a are the same, the content is not updated. In these cases a
+`204 No Content` response is returned.
+
+This response will have an empty body per HTTP schemantics.
+
+```json
+{
+  "contents": {
+    "id": 119,
+    "body": "<html/>"
+  }
+}
+```
+
+### Response <a href="#updating-a-content-not-changing-an-attribute-response" class="header-link"></a>
+
+```
+Status: 204 No Content
+CampaignKit-Media-Type: campaignkit.v1
+CampaignKit-API-Version: 1.0
+```
+
+### Curl Example <a href="#updating-a-content-not-changing-an-attribute-curl-example" class="header-link"></a>
+
+```
+curl https://campaignkit.radiusnetworks.com/api/v1/contents/119 \
+  -is \
+  -X PUT \
+  -H 'Accept: application/vnd.rn+json' \
+  -H 'Content-Type: application/vnd.rn+json' \
+  -H 'Authorization: Token token="c0decafe1111180a29c8696adbd5307ccdcdaa6468c0ffee"' \
+  -d '{
+    "contents": {
+      "id": 119,
+      "body": "<html/>"
+    }
+  }'
+```
+
+## Deleting A Content <a href="#deleting-a-content" class="header-link"></a>
+
+```
+DELETE /api/v1/contents/150
+```
+
+In order to delete a content, the authenticated user must be a member of
+the kit that the content is associated with.
+
+### Response <a href="#deleting-a-content-response" class="header-link"></a>
+
+```
+Status: 204 No Content
+CampaignKit-Media-Type: campaignkit.v1
+CampaignKit-API-Version: 1.0
+```
+
+### Curl Example <a href="#deleting-a-content-curl-example" class="header-link"></a>
+
+```
+curl https://campaignkit.radiusnetworks.com/api/v1/contents/150 \
+  -is \
+  -X DELETE \
+  -H 'Accept: application/vnd.rn+json' \
+  -H 'Content-Type: application/vnd.rn+json' \
+  -H 'Authorization: Token token="c0decafe1111180a29c8696adbd5307ccdcdaa6468c0ffee"'
+```

--- a/docs/api/v1/kits.md
+++ b/docs/api/v1/kits.md
@@ -1,0 +1,204 @@
+# Kits API
+
+- [Getting A Kit](#getting-a-kit)
+- [Updating A Kit Changing An Attribute](#updating-a-kit-changing-an-attribute)
+- [Updating A Kit Not Changing An Attribute](#updating-a-kit-not-changing-an-attribute)
+
+A kit is tied to your Campaign Kit mobile app. You can add assets, content,
+places, and campaigns to your kit.
+
+## Headers <a href="#headers" id="headers" class="headerlink"></a>
+
+### Authorization <a href="#authorization" id="authorization" class="headerlink"></a>
+
+The API Key is passed via the Authorization header:
+
+```
+Authorization: Token token="secret"
+```
+
+The API Key is associated with your account and has access to all the resources
+associated with your account. Account specific API keys have different
+permissions than the web login users that can interact with the dashboard, and
+the access may be different.
+
+If you do not have an API key, [you can create one here](https://account.radiusnetworks.com/personal_token).
+
+**Note:** Per [RFC 2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2.2) the Authorization Header's token needs to be
+surrounded by double quotes (`"`).
+
+### Content Type <a href="#content-type" id="content-type" class="headerlink"></a>
+
+The content type is `vnd.rn+json` and should be set in the `Content-Type`
+header:
+
+```
+Content-Type: application/vnd.rn+json
+```
+
+## Getting A Kit <a href="#getting-a-kit" class="header-link"></a>
+
+```
+GET /api/v1/kits/3
+```
+
+List a specific kit for the authenticated user. The desired kit's `id` needs to be provided in the URL.
+
+### Response <a href="#getting-a-kit-response" class="header-link"></a>
+
+```
+Status: 200 OK
+Content-Type: application/json; charset=utf-8
+CampaignKit-Media-Type: campaignkit.v1
+CampaignKit-API-Version: 1.0
+```
+```json
+{
+  "links": {
+    "kits.places": "https://campaignkit.radiusnetworks.com/api/v1/places/{kits.places}",
+    "kits.campaigns": "https://campaignkit.radiusnetworks.com/api/v1/campaigns/{kits.campaigns}",
+    "kits.contents": "https://campaignkit.radiusnetworks.com/api/v1/contents/{kits.contents}",
+    "kits.assets": "https://campaignkit.radiusnetworks.com/api/v1/assets/{kits.assets}"
+  },
+  "kits": [
+    {
+      "id": "3",
+      "name": "snikofhuujmsbckocdfm",
+      "created_at": "2015-07-06T18:03:36.126Z",
+      "updated_at": "2015-07-06T18:03:36.126Z",
+      "links": {
+        "self": "https://campaignkit.radiusnetworks.com/api/v1/kits/3",
+        "places": [
+
+        ],
+        "campaigns": [
+
+        ],
+        "contents": [
+
+        ],
+        "assets": [
+
+        ]
+      }
+    }
+  ]
+}
+```
+
+### Curl Example <a href="#getting-a-kit-curl-example" class="header-link"></a>
+
+```
+curl https://campaignkit.radiusnetworks.com/api/v1/kits/3 \
+  -is \
+  -X GET \
+  -H 'Accept: application/vnd.rn+json' \
+  -H 'Content-Type: application/vnd.rn+json' \
+  -H 'Authorization: Token token="c0decafe1111180a29c8696adbd5307ccdcdaa6468c0ffee"'
+```
+
+## Updating A Kit Changing An Attribute <a href="#updating-a-kit-changing-an-attribute" class="header-link"></a>
+
+```
+PUT /api/v1/kits/2
+```
+
+Kits are created and typically managed on the Campaign Kit server.
+However, the name can be updated via this API.
+
+### Parameters <a href="#updating-a-kit-changing-an-attribute-parameters" class="header-link"></a>
+
+All kits **must** be sent in an array nested under a top level
+`kits` parameter.
+
+| **Name** | **Type** | **Description** |
+| -------- | -------- | --------------- |
+| `id` | `string` | **Required.** The kit's id |
+| `name` | `string` | The kit's unique name |
+
+### Example <a href="#updating-a-kit-changing-an-attribute-example" class="header-link"></a>
+
+Successfully updating a kit modifies the `updated_at` field. Since
+this field is updated internally, the full kit resource is returned in
+the response body.
+
+```json
+{
+  "kits": {
+    "id": 2,
+    "name": "New Name"
+  }
+}
+```
+
+### Response <a href="#updating-a-kit-changing-an-attribute-response" class="header-link"></a>
+
+```
+Status: 200 OK
+Content-Type: application/json; charset=utf-8
+CampaignKit-Media-Type: campaignkit.v1
+CampaignKit-API-Version: 1.0
+```
+```json
+{
+  "links": {
+    "kits.places": "https://campaignkit.radiusnetworks.com/api/v1/places/{kits.places}",
+    "kits.campaigns": "https://campaignkit.radiusnetworks.com/api/v1/campaigns/{kits.campaigns}",
+    "kits.contents": "https://campaignkit.radiusnetworks.com/api/v1/contents/{kits.contents}",
+    "kits.assets": "https://campaignkit.radiusnetworks.com/api/v1/assets/{kits.assets}"
+  },
+  "kits": [
+    {
+      "id": "2",
+      "name": "New Name",
+      "created_at": "2015-07-06T18:03:36.320Z",
+      "updated_at": "2015-07-06T18:03:36.335Z",
+      "links": {
+        "self": "https://campaignkit.radiusnetworks.com/api/v1/kits/2",
+        "places": [
+
+        ],
+        "campaigns": [
+
+        ],
+        "contents": [
+
+        ],
+        "assets": [
+
+        ]
+      }
+    }
+  ]
+}
+```
+
+### Curl Example <a href="#updating-a-kit-changing-an-attribute-curl-example" class="header-link"></a>
+
+```
+curl https://campaignkit.radiusnetworks.com/api/v1/kits/2 \
+  -is \
+  -X PUT \
+  -H 'Accept: application/vnd.rn+json' \
+  -H 'Content-Type: application/vnd.rn+json' \
+  -H 'Authorization: Token token="c0decafe1111180a29c8696adbd5307ccdcdaa6468c0ffee"' \
+  -d '{
+    "kits": {
+      "id": 2,
+      "name": "New Name"
+    }
+  }'
+```
+
+## Updating A Kit Not Changing An Attribute <a href="#updating-a-kit-not-changing-an-attribute" class="header-link"></a>
+
+### Parameters <a href="#updating-a-kit-not-changing-an-attribute-parameters" class="header-link"></a>
+
+All kits **must** be sent in an array nested under a top level
+`kits` parameter.
+
+| **Name** | **Type** | **Description** |
+| -------- | -------- | --------------- |
+| `id` | `string` | **Required.** The kit's id |
+| `name` | `string` | The kit's unique name |
+

--- a/docs/api/v1/places.md
+++ b/docs/api/v1/places.md
@@ -1,0 +1,459 @@
+# Places API
+
+- [Listing A Kit's Places](#listing-a-kit's-places)
+- [Getting A Place](#getting-a-place)
+- [Creating A Place](#creating-a-place)
+- [Updating A Place Changing An Attribute](#updating-a-place-changing-an-attribute)
+- [Updating A Place Not Changing An Attribute](#updating-a-place-not-changing-an-attribute)
+- [Deleting A Place](#deleting-a-place)
+
+All actions against places require at a minimum an authenticated user who
+is the owner, or a member of the kit to which the kit belongs.
+
+## Headers <a href="#headers" id="headers" class="headerlink"></a>
+
+### Authorization <a href="#authorization" id="authorization" class="headerlink"></a>
+
+The API Key is passed via the Authorization header:
+
+```
+Authorization: Token token="secret"
+```
+
+The API Key is associated with your account and has access to all the resources
+associated with your account. Account specific API keys have different
+permissions than the web login users that can interact with the dashboard, and
+the access may be different.
+
+If you do not have an API key, [you can create one here](https://account.radiusnetworks.com/personal_token).
+
+**Note:** Per [RFC 2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2.2) the Authorization Header's token needs to be
+surrounded by double quotes (`"`).
+
+### Content Type <a href="#content-type" id="content-type" class="headerlink"></a>
+
+The content type is `vnd.rn+json` and should be set in the `Content-Type`
+header:
+
+```
+Content-Type: application/vnd.rn+json
+```
+
+## Listing A Kit's Places <a href="#listing-a-kit's-places" class="header-link"></a>
+
+```
+GET /api/v1/kits/4/places
+```
+
+List places for the specified kit.
+
+Places are associated to a specific `Kit`. The desired kit's `id`
+must be provided in the URL.
+
+### Response <a href="#listing-a-kit's-places-response" class="header-link"></a>
+
+```
+Status: 200 OK
+Content-Type: application/json; charset=utf-8
+CampaignKit-Media-Type: campaignkit.v1
+CampaignKit-API-Version: 1.0
+```
+```json
+{
+  "links": {
+    "places.kit": "https://campaignkit.radiusnetworks.com/api/v1/kits/{places.kit}"
+  },
+  "places": [
+    {
+      "id": "26",
+      "name": "RSpec Place 1-3001341d",
+      "latitude": null,
+      "longitude": null,
+      "address": null,
+      "radius": null,
+      "uuid": "a9924003-bc4f-4cc7-98f5-adad48cf4c6f",
+      "major": 75,
+      "minor": 58,
+      "type": null,
+      "created_at": "2015-07-06T18:03:36.607Z",
+      "updated_at": "2015-07-06T18:03:36.607Z",
+      "links": {
+        "kit": "4",
+        "parent": ""
+      }
+    },
+    {
+      "id": "27",
+      "name": "RSpec Place 2-3001341d",
+      "latitude": null,
+      "longitude": null,
+      "address": null,
+      "radius": null,
+      "uuid": "9860f506-b9b9-4de3-936f-b7b819ea789a",
+      "major": 14,
+      "minor": 97,
+      "type": null,
+      "created_at": "2015-07-06T18:03:36.613Z",
+      "updated_at": "2015-07-06T18:03:36.613Z",
+      "links": {
+        "kit": "4",
+        "parent": ""
+      }
+    }
+  ]
+}
+```
+
+### Curl Example <a href="#listing-a-kit's-places-curl-example" class="header-link"></a>
+
+```
+curl https://campaignkit.radiusnetworks.com/api/v1/kits/4/places \
+  -is \
+  -X GET \
+  -H 'Accept: application/vnd.rn+json' \
+  -H 'Content-Type: application/vnd.rn+json' \
+  -H 'Authorization: Token token="c0decafe1111180a29c8696adbd5307ccdcdaa6468c0ffee"'
+```
+
+## Getting A Place <a href="#getting-a-place" class="header-link"></a>
+
+```
+GET /api/v1/places/37
+```
+
+List a specific place for the authenticated user. The desired places's `id` needs to be provided in the URL.
+
+### Response <a href="#getting-a-place-response" class="header-link"></a>
+
+```
+Status: 200 OK
+Content-Type: application/json; charset=utf-8
+CampaignKit-Media-Type: campaignkit.v1
+CampaignKit-API-Version: 1.0
+```
+```json
+{
+  "links": {
+    "places.kit": "https://campaignkit.radiusnetworks.com/api/v1/kits/{places.kit}"
+  },
+  "places": [
+    {
+      "id": "37",
+      "name": "RSpec Place 1-ebbe4c25",
+      "latitude": null,
+      "longitude": null,
+      "address": null,
+      "radius": null,
+      "uuid": "1b8447e8-fb4d-435f-93f5-547db57afaf4",
+      "major": 82,
+      "minor": 36,
+      "type": null,
+      "created_at": "2015-07-06T18:03:36.801Z",
+      "updated_at": "2015-07-06T18:03:36.801Z",
+      "links": {
+        "kit": "2",
+        "parent": ""
+      }
+    }
+  ]
+}
+```
+
+### Curl Example <a href="#getting-a-place-curl-example" class="header-link"></a>
+
+```
+curl https://campaignkit.radiusnetworks.com/api/v1/places/37 \
+  -is \
+  -X GET \
+  -H 'Accept: application/vnd.rn+json' \
+  -H 'Content-Type: application/vnd.rn+json' \
+  -H 'Authorization: Token token="c0decafe1111180a29c8696adbd5307ccdcdaa6468c0ffee"'
+```
+
+## Creating A Place <a href="#creating-a-place" class="header-link"></a>
+
+```
+POST /api/v1/kits/1/places
+```
+
+Create a place for the specified kit. The desired kit's `id` must be
+provided in the URL. In order to create a place, the authenticated
+user must be a member of the kit.
+
+### Parameters <a href="#creating-a-place-parameters" class="header-link"></a>
+
+All places **must** be sent in an array nested under a top level
+`places` parameter.
+
+| **Name** | **Type** | **Description** |
+| -------- | -------- | --------------- |
+| `name` | `string` | Display name of the place (e.g. Front Door, Register, Shoe Rack) |
+| `latitude` | `string` | The latitude of the place as a geofence |
+| `longitude` | `string` | The longitude of the place as a geofence |
+| `address` | `string` | The address of the place as a geofence |
+| `radius` | `integer` | The radius of the place as a geofence |
+| `uuid` | `string` | The proximity UUID of the place as a beacon |
+| `major` | `integer` | The major value of the place as a beacon |
+| `minor` | `integer` | The minor value of the place as a beacon |
+| `type` | `integer` | The minor value of the place as a beacon |
+
+### Example <a href="#creating-a-place-example" class="header-link"></a>
+
+A successful place creation returns the generated place document with
+updated timestamps.
+
+```json
+{
+  "places": {
+    "name": "RSpec Place 1-c64002d9",
+    "uuid": "9234e964-7123-4b97-9c8b-8b9c76f2e4a2",
+    "major": 81,
+    "minor": 32
+  }
+}
+```
+
+### Response <a href="#creating-a-place-response" class="header-link"></a>
+
+```
+Status: 201 Created
+Content-Type: application/json; charset=utf-8
+CampaignKit-Media-Type: campaignkit.v1
+CampaignKit-API-Version: 1.0
+```
+```json
+{
+  "links": {
+    "places.kit": "https://campaignkit.radiusnetworks.com/api/v1/kits/{places.kit}"
+  },
+  "places": [
+    {
+      "id": "72",
+      "name": "RSpec Place 1-c64002d9",
+      "latitude": null,
+      "longitude": null,
+      "address": null,
+      "radius": null,
+      "uuid": "9234e964-7123-4b97-9c8b-8b9c76f2e4a2",
+      "major": 81,
+      "minor": 32,
+      "type": null,
+      "created_at": "2015-07-06T18:03:37.218Z",
+      "updated_at": "2015-07-06T18:03:37.218Z",
+      "links": {
+        "kit": "1",
+        "parent": ""
+      }
+    }
+  ]
+}
+```
+
+### Curl Example <a href="#creating-a-place-curl-example" class="header-link"></a>
+
+```
+curl https://campaignkit.radiusnetworks.com/api/v1/kits/1/places \
+  -is \
+  -X POST \
+  -H 'Accept: application/vnd.rn+json' \
+  -H 'Content-Type: application/vnd.rn+json' \
+  -H 'Authorization: Token token="c0decafe1111180a29c8696adbd5307ccdcdaa6468c0ffee"' \
+  -d '{
+    "places": {
+      "name": "RSpec Place 1-c64002d9",
+      "uuid": "9234e964-7123-4b97-9c8b-8b9c76f2e4a2",
+      "major": 81,
+      "minor": 32
+    }
+  }'
+```
+
+## Updating A Place Changing An Attribute <a href="#updating-a-place-changing-an-attribute" class="header-link"></a>
+
+```
+PUT /api/v1/places/98
+```
+
+In order to update a place, the authenticated user must be a member of
+the kit that the place is associated with.
+
+### Parameters <a href="#updating-a-place-changing-an-attribute-parameters" class="header-link"></a>
+
+All places **must** be sent in an array nested under a top level
+`places` parameter.
+
+| **Name** | **Type** | **Description** |
+| -------- | -------- | --------------- |
+| `id` | `string` | **Required.** The id of the place |
+| `name` | `string` | Display name of the place (e.g. Front Door, Register, Shoe Rack) |
+| `latitude` | `string` | The latitude of the place as a geofence |
+| `longitude` | `string` | The longitude of the place as a geofence |
+| `address` | `string` | The address of the place as a geofence |
+| `radius` | `integer` | The radius of the place as a geofence |
+| `uuid` | `string` | The proximity UUID of the place as a beacon |
+| `major` | `integer` | The major value of the place as a beacon |
+| `minor` | `integer` | The minor value of the place as a beacon |
+| `type` | `integer` | The minor value of the place as a beacon |
+
+### Example <a href="#updating-a-place-changing-an-attribute-example" class="header-link"></a>
+
+A successful update modifies the place's `updated_at` field.
+
+```json
+{
+  "places": {
+    "id": 98,
+    "uuid": "7c660318-35c4-4e87-8e7e-d8a954ae959f"
+  }
+}
+```
+
+### Response <a href="#updating-a-place-changing-an-attribute-response" class="header-link"></a>
+
+```
+Status: 200 OK
+Content-Type: application/json; charset=utf-8
+CampaignKit-Media-Type: campaignkit.v1
+CampaignKit-API-Version: 1.0
+```
+```json
+{
+  "links": {
+    "places.kit": "https://campaignkit.radiusnetworks.com/api/v1/kits/{places.kit}"
+  },
+  "places": [
+    {
+      "id": "98",
+      "name": "RSpec Place 2-6635c43b",
+      "latitude": null,
+      "longitude": null,
+      "address": null,
+      "radius": null,
+      "uuid": "7c660318-35c4-4e87-8e7e-d8a954ae959f",
+      "major": 58,
+      "minor": 83,
+      "type": null,
+      "created_at": "2015-07-06T18:03:37.573Z",
+      "updated_at": "2015-07-06T18:03:37.605Z",
+      "links": {
+        "kit": "2",
+        "parent": ""
+      }
+    }
+  ]
+}
+```
+
+### Curl Example <a href="#updating-a-place-changing-an-attribute-curl-example" class="header-link"></a>
+
+```
+curl https://campaignkit.radiusnetworks.com/api/v1/places/98 \
+  -is \
+  -X PUT \
+  -H 'Accept: application/vnd.rn+json' \
+  -H 'Content-Type: application/vnd.rn+json' \
+  -H 'Authorization: Token token="c0decafe1111180a29c8696adbd5307ccdcdaa6468c0ffee"' \
+  -d '{
+    "places": {
+      "id": 98,
+      "uuid": "7c660318-35c4-4e87-8e7e-d8a954ae959f"
+    }
+  }'
+```
+
+## Updating A Place Not Changing An Attribute <a href="#updating-a-place-not-changing-an-attribute" class="header-link"></a>
+
+```
+PUT /api/v1/places/114
+```
+
+In order to update a place, the authenticated user must be a member of
+the kit that the place is associated with.
+
+### Parameters <a href="#updating-a-place-not-changing-an-attribute-parameters" class="header-link"></a>
+
+All places **must** be sent in an array nested under a top level
+`places` parameter.
+
+| **Name** | **Type** | **Description** |
+| -------- | -------- | --------------- |
+| `id` | `string` | **Required.** The id of the place |
+| `name` | `string` | Display name of the place (e.g. Front Door, Register, Shoe Rack) |
+| `latitude` | `string` | The latitude of the place as a geofence |
+| `longitude` | `string` | The longitude of the place as a geofence |
+| `address` | `string` | The address of the place as a geofence |
+| `radius` | `integer` | The radius of the place as a geofence |
+| `uuid` | `string` | The proximity UUID of the place as a beacon |
+| `major` | `integer` | The major value of the place as a beacon |
+| `minor` | `integer` | The minor value of the place as a beacon |
+| `type` | `integer` | The minor value of the place as a beacon |
+
+### Example <a href="#updating-a-place-not-changing-an-attribute-example" class="header-link"></a>
+
+If you do not provide attributes, or if all of the provided attributes
+for a are the same, the place is not updated. In these cases a
+`204 No Content` response is returned.
+
+This response will have an empty body per HTTP schemantics.
+
+```json
+{
+  "places": {
+    "id": 114,
+    "uuid": "29201587-1591-4c02-b446-210d02ea8107"
+  }
+}
+```
+
+### Response <a href="#updating-a-place-not-changing-an-attribute-response" class="header-link"></a>
+
+```
+Status: 204 No Content
+CampaignKit-Media-Type: campaignkit.v1
+CampaignKit-API-Version: 1.0
+```
+
+### Curl Example <a href="#updating-a-place-not-changing-an-attribute-curl-example" class="header-link"></a>
+
+```
+curl https://campaignkit.radiusnetworks.com/api/v1/places/114 \
+  -is \
+  -X PUT \
+  -H 'Accept: application/vnd.rn+json' \
+  -H 'Content-Type: application/vnd.rn+json' \
+  -H 'Authorization: Token token="c0decafe1111180a29c8696adbd5307ccdcdaa6468c0ffee"' \
+  -d '{
+    "places": {
+      "id": 114,
+      "uuid": "29201587-1591-4c02-b446-210d02ea8107"
+    }
+  }'
+```
+
+## Deleting A Place <a href="#deleting-a-place" class="header-link"></a>
+
+```
+DELETE /api/v1/places/131
+```
+
+In order to delete a place, the authenticated user must be a member of
+the kit that the place is associated with.
+
+### Response <a href="#deleting-a-place-response" class="header-link"></a>
+
+```
+Status: 204 No Content
+CampaignKit-Media-Type: campaignkit.v1
+CampaignKit-API-Version: 1.0
+```
+
+### Curl Example <a href="#deleting-a-place-curl-example" class="header-link"></a>
+
+```
+curl https://campaignkit.radiusnetworks.com/api/v1/places/131 \
+  -is \
+  -X DELETE \
+  -H 'Accept: application/vnd.rn+json' \
+  -H 'Content-Type: application/vnd.rn+json' \
+  -H 'Authorization: Token token="c0decafe1111180a29c8696adbd5307ccdcdaa6468c0ffee"'
+```

--- a/docs/api/v1/root_endpoint.md
+++ b/docs/api/v1/root_endpoint.md
@@ -1,0 +1,75 @@
+# Campaign Kit API Root Endpoint
+
+- [Requesting Resource Endpoints](#requesting-resource-endpoints)
+
+This describes the resources that make up the official Campaign Kit API v1.
+If you have any problems or requests please contact
+[support](http://www.radiusnetworks.com/support.html). Issue a `GET`
+request to the root endpoint to get a list of all the resource endpoints
+this API supports.
+
+## Headers <a href="#headers" id="headers" class="headerlink"></a>
+
+### Authorization <a href="#authorization" id="authorization" class="headerlink"></a>
+
+The API Key is passed via the Authorization header:
+
+```
+Authorization: Token token="secret"
+```
+
+The API Key is associated with your account and has access to all the resources
+associated with your account. Account specific API keys have different
+permissions than the web login users that can interact with the dashboard, and
+the access may be different.
+
+If you do not have an API key, [you can create one here](https://account.radiusnetworks.com/personal_token).
+
+**Note:** Per [RFC 2616](http://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2.2) the Authorization Header's token needs to be
+surrounded by double quotes (`"`).
+
+### Content Type <a href="#content-type" id="content-type" class="headerlink"></a>
+
+The content type is `vnd.rn+json` and should be set in the `Content-Type`
+header:
+
+```
+Content-Type: application/vnd.rn+json
+```
+
+## Requesting Resource Endpoints <a href="#requesting-resource-endpoints" class="header-link"></a>
+
+```
+GET /api/v1
+```
+
+### Response <a href="#requesting-resource-endpoints-response" class="header-link"></a>
+
+```
+Status: 200 OK
+Content-Type: application/json; charset=utf-8
+CampaignKit-Media-Type: campaignkit.v1
+CampaignKit-API-Version: 1.0
+```
+```json
+{
+  "links": {
+    "users.kits": "https://campaignkit.radiusnetworks.com/api/v1/kits/{users.kits}",
+    "kits.places": "https://campaignkit.radiusnetworks.com/api/v1/places/{kits.places}",
+    "kits.campaigns": "https://campaignkit.radiusnetworks.com/api/v1/campaigns/{kits.campaigns}",
+    "kits.contents": "https://campaignkit.radiusnetworks.com/api/v1/contents/{kits.contents}",
+    "kits.assets": "https://campaignkit.radiusnetworks.com/api/v1/assets/{kits.assets}"
+  }
+}
+```
+
+### Curl Example <a href="#requesting-resource-endpoints-curl-example" class="header-link"></a>
+
+```
+curl https://campaignkit.radiusnetworks.com/api/v1 \
+  -is \
+  -X GET \
+  -H 'Accept: application/vnd.rn+json' \
+  -H 'Content-Type: application/vnd.rn+json' \
+  -H 'Authorization: Token token="c0decafe1111180a29c8696adbd5307ccdcdaa6468c0ffee"'
+```

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -12,6 +12,9 @@ Campaign Kit is a cloud-based service coupled with mobile SDKs that enables you 
 * [JavaDocs](http://developer.radiusnetworks.com/campaignkit/android/javadocs/index.html)
 * [Notes on suppressing multiple notifications](http://developer.radiusnetworks.com/campaignkit/android/suppressing-multiple-campaigns.html)
 
+# Admin API Documentation
+* [Restful JSON Admin API](api)
+
 # Component Overview
 
 ## What is a Kit?


### PR DESCRIPTION
These were generated from the rake task. Documents the public API for managing Campaign Kit resources.